### PR TITLE
chore: depend only on num-traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ readme = "README.md"
 travis-ci = { repository = "plausiblelabs/rcodec" }
 
 [dependencies]
-num = "0.2.0"
+num-traits = "0.2.0"
 pl-hlist = "1.0.0"

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -15,7 +15,7 @@ use std::mem::size_of;
 use std::ptr;
 use std::slice;
 
-use num::traits::{FromPrimitive, PrimInt, Unsigned};
+use num_traits::{FromPrimitive, PrimInt, Unsigned};
 
 use pl_hlist::*;
 


### PR DESCRIPTION
We only need to depend on num-traits, since that is all we use from the num umbrella crate.